### PR TITLE
Skip install when CI_SKIP_TARTUFO env var present

### DIFF
--- a/lib/install-local.js
+++ b/lib/install-local.js
@@ -16,6 +16,12 @@ const { VENV_PATH, VENV_BIN_PATH } = require("./venv");
  * never pollute or override global installs.
  */
 async function installTartufoLocal() {
+  /* eslint-disable-next-line no-process-env */
+  if (process.env.CI_SKIP_TARTUFO) {
+    console.log("Skipping Tartufo install due to CI_SKIP_TARTUFO");
+    return;
+  }
+
   const tartufo = await tartufoSystem();
 
   if (tartufo) {


### PR DESCRIPTION
Introduces the CI_SKIP_TARTUFO env var which is checked in the npm `postinstall` script phase. If present, tartufo will fully skip the postinstall process. This is primarily for CI environments that do not require tartufo to be present.