### PR TITLE
Add better error handling to install process

### DIFF
--- a/bin/tartufo-helper.js
+++ b/bin/tartufo-helper.js
@@ -66,6 +66,7 @@ async function commandDoctor() {
     console.log(chalk.white.bgRed("Tartufo not found globally or locally!!"));
     console.log("");
     console.log(chalk`We recommend running {cyan npx tartufo-helper reset} to reinstall tartufo locally`);
+    console.log(chalk`You may also re-run this command with DEBUG=tartufo-node to see verbose logs`);
     process.exit(1);
   }
 
@@ -99,6 +100,7 @@ async function commandDoctor() {
   console.log(
     chalk`{green Your system is ready to use Tartufo!} You can try it out by running {cyan npx tartufo --version}`
   );
+  console.log(chalk`You may also re-run this command with DEBUG=tartufo-node to see verbose logs`);
 }
 
 async function commandReset() {

--- a/lib/install-local.js
+++ b/lib/install-local.js
@@ -51,10 +51,22 @@ async function installTartufoLocal() {
   }
 
   debug("Settuping up venv...");
-  await streamSpawn(debug, python3, ["-m", "venv", VENV_PATH]);
+  try {
+    await streamSpawn(debug, python3, ["-m", "venv", VENV_PATH]);
+  } catch (e) {
+    console.log(chalk.white.bgRed(`Tartufo failed to setup a local venv.`));
+    console.log(`Please run npx tartufo-helper doctor for more information on how to resolve`);
+    return;
+  }
 
   debug("Installing tartufo...");
-  await streamSpawn(debug, path.join(VENV_BIN_PATH, "python"), ["-m", "pip", "install", "tartufo"]);
+  try {
+    await streamSpawn(debug, path.join(VENV_BIN_PATH, "python"), ["-m", "pip", "install", "tartufo"]);
+  } catch (e) {
+    console.log(chalk.white.bgRed(`Tartufo failed to install.`));
+    console.log(`Please run npx tartufo-helper doctor for more information on how to resolve`);
+    return;
+  }
 }
 
 module.exports = installTartufoLocal;

--- a/lib/python-version.js
+++ b/lib/python-version.js
@@ -1,4 +1,5 @@
 const { promisify } = require("util");
+const debug = require("debug")("tartufo-node");
 const exec = promisify(require("child_process").exec);
 
 /**
@@ -8,11 +9,21 @@ const exec = promisify(require("child_process").exec);
  * @returns {[number, number, number] | []} Returns array of [major, minor, patch] or empty array on failure
  */
 async function pythonVersion(pythonPath) {
+  let stdout;
+  let stderr;
   try {
-    const { stdout } = await exec(`${pythonPath} --version`);
+    debug(`sh: ${pythonPath} --version`);
+    const res = await exec(`${pythonPath} --version`);
+    stdout = res.stdout;
+    stderr = res.stderr;
+    stdout && debug(`sh: ${stdout.trimEnd()}`);
+    stderr && debug(`sh: ${stderr.trimEnd()}`);
     const [, version] = stdout.trim().split(" ");
     return version.split(".").map(v => Number(v));
   } catch (e) {
+    stdout && debug(`sh: ${stdout.trimEnd()}`);
+    stderr && debug(`sh: ${stderr.trimEnd()}`);
+    debug(`Failed to parse Python version, expected "Python X.X.X"`);
     return [];
   }
 }

--- a/lib/stream-spawn.js
+++ b/lib/stream-spawn.js
@@ -10,9 +10,10 @@ const { spawn } = require("child_process");
  */
 async function streamSpawn(log, cmd, args = [], options = {}) {
   return new Promise((resolve, reject) => {
+    log(`sh: ${cmd} ${args.join(" ")}`);
     const subprocess = spawn(cmd, args, options);
-    subprocess.stderr.on("data", data => log(String(data)));
-    subprocess.stdout.on("data", data => log(String(data)));
+    subprocess.stderr.on("data", data => log(`sh: ${String(data).trimEnd()}`));
+    subprocess.stdout.on("data", data => log(`sh: ${String(data).trimEnd()}`));
     subprocess.on("close", code => {
       if (Number(code) === 0) return resolve();
       reject(code);


### PR DESCRIPTION
Installs were failing on macOS Monterey, _possibly_ due to missing or incorrectly installed python versions. I cannot confirm but I believe macOS Monterey might provide a shim `python` in the system PATH now. Installs would pass version checks but fail to setup a venv.

This PR adds better error handling and debugging output to assist with future issues.