### PR TITLE
Reduce npm package size by excluding unnecessary files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
     "version": "auto-changelog -p --tag-prefix='' && git add CHANGELOG.md",
     "precommit:tartufo": "node ./bin/tartufo-shim.js pre-commit"
   },
+  "files": [
+    "bin/*",
+    "lib/*",
+    "SECURITY.md"
+  ],
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/godaddy/tartufo-node.git"


### PR DESCRIPTION
This reduces the unpacked size of this package from 289.9kb to about 24.0kb