### PR TITLE
add on error handler for spawn

### DIFF
--- a/lib/stream-spawn.js
+++ b/lib/stream-spawn.js
@@ -12,9 +12,13 @@ async function streamSpawn(log, cmd, args = [], options = {}) {
   return new Promise((resolve, reject) => {
     log(`sh: ${cmd} ${args.join(" ")}`);
     const subprocess = spawn(cmd, args, options);
-    subprocess.stderr.on("data", data => log(`sh: ${String(data).trimEnd()}`));
-    subprocess.stdout.on("data", data => log(`sh: ${String(data).trimEnd()}`));
-    subprocess.on("close", code => {
+    subprocess.stderr.on("data", (data) => log(`sh: ${String(data).trimEnd()}`));
+    subprocess.stdout.on("data", (data) => log(`sh: ${String(data).trimEnd()}`));
+    subprocess.on("error", (err) => {
+      log(err);
+      reject(err);
+    });
+    subprocess.on("close", (code) => {
       if (Number(code) === 0) return resolve();
       reject(code);
     });


### PR DESCRIPTION
If the spawn command fails it won't be detected and will throw an uncaught exception.