### PR TITLE
Add ability to determine if libgit2 is installed

### DIFF
--- a/bin/tartufo-helper.js
+++ b/bin/tartufo-helper.js
@@ -8,6 +8,7 @@ const pythonSystem = require("../lib/python-system");
 const pythonLocal = require("../lib/python-local");
 const pythonVersion = require("../lib/python-version");
 const pythonMeetsMinimum = require("../lib/python-meets-minimum");
+const hasGit2Header = require("../lib/git2-header");
 
 // eslint-disable-next-line complexity, max-statements
 async function commandDoctor() {
@@ -17,11 +18,18 @@ async function commandDoctor() {
 
   const pythonSystemPath = await pythonSystem();
   const pythonLocalPath = await pythonLocal();
+  const git2Header = await hasGit2Header();
 
   if (!pythonSystemPath) {
-    console.log(chalk.white.bgRed(`Python not found globally or locally at either 'python3' or 'python'`));
+    console.log(
+      chalk.white.bgRed(
+        `Python not found globally or locally at either 'python3' or 'python'`,
+      ),
+    );
     console.log("");
-    console.log("We recommend following best practices for installing python on your local machine");
+    console.log(
+      "We recommend following best practices for installing python on your local machine",
+    );
     process.exit(1);
   } else {
     const pythonSystemVersion = await pythonVersion(pythonSystemPath);
@@ -32,16 +40,23 @@ async function commandDoctor() {
     } else {
       pythonSystemDisplayVersion = chalk.red(pythonSystemVersion.join("."));
     }
-    console.log(chalk`System\t{cyan Python}\tVersion: ${pythonSystemDisplayVersion}`);
+    console.log(
+      chalk`System\t{cyan Python}\tVersion: ${pythonSystemDisplayVersion}`,
+    );
     if (!pythonSystemMeetsMinimum) {
       console.log(
-        chalk.yellow(`! Your system Python does not meet the requirements of ${pythonMeetsMinimum.MINIMUM_READABLE}.`)
+        chalk.yellow(
+          `! Your system Python does not meet the requirements of ${pythonMeetsMinimum.MINIMUM_READABLE}.`,
+        ),
       );
     }
   }
 
   if (!pythonLocalPath) {
-    console.log(chalk`Local\t{cyan Python}\t{yellow was not found.} (Expected if using system tartufo)`);
+    console.log(
+      chalk
+        `Local\t{cyan Python}\t{yellow was not found.} (Expected if using system tartufo)`,
+    );
   } else {
     const pythonLocalVersion = await pythonVersion(pythonLocalPath);
     const pythonLocalMeetsMinimum = pythonMeetsMinimum(pythonLocalVersion);
@@ -51,56 +66,96 @@ async function commandDoctor() {
     } else {
       pythonLocalDisplayVersion = chalk.red(pythonLocalVersion.join("."));
     }
-    console.log(chalk`Local\t{cyan Python}\tVersion: ${pythonLocalDisplayVersion}`);
+    console.log(
+      chalk`Local\t{cyan Python}\tVersion: ${pythonLocalDisplayVersion}`,
+    );
     if (!pythonLocalMeetsMinimum) {
       console.log(
         chalk.yellow(
-          `! Your local (venv) Python does not meet the requirements of ${pythonMeetsMinimum.MINIMUM_READABLE}.`
-        )
+          `! Your local (venv) Python does not meet the requirements of ${pythonMeetsMinimum.MINIMUM_READABLE}.`,
+        ),
       );
     }
+  }
+
+  if (!git2Header) {
+    console.log(
+      chalk
+        `Local\t{cyan libgit2}\t{yellow was not found.} (libgit2 is required to install Tartufo)`,
+    );
+    console.log(
+      chalk
+        `Local\t{cyan libgit2}\tPlease run \`brew install libgit2\` (or similar command for your system)`,
+    );
   }
 
   if (!tartufo) {
     console.log("");
     console.log(chalk.white.bgRed("Tartufo not found globally or locally!!"));
     console.log("");
-    console.log(chalk`We recommend running {cyan npx tartufo-helper reset} to reinstall tartufo locally`);
-    console.log(chalk`You may also re-run this command with DEBUG=tartufo-node to see verbose logs`);
+    console.log(
+      chalk
+        `We recommend running {cyan npx tartufo-helper reset} to reinstall tartufo locally`,
+    );
+    console.log(
+      chalk
+        `You may also re-run this command with DEBUG=tartufo-node to see verbose logs`,
+    );
     process.exit(1);
   }
 
   if (!tartufoSystemPath) {
-    console.log(chalk`System\t{cyan Tartufo}\t{yellow was not found.} (Expected if using local tartufo)`);
+    console.log(
+      chalk
+        `System\t{cyan Tartufo}\t{yellow was not found.} (Expected if using local tartufo)`,
+    );
   } else {
     const tartufoSystemVersion = await tartufoVersion(tartufoSystemPath);
     console.log(
-      chalk`System\t{cyan Tartufo}\tVersion: {green ${tartufoSystemVersion.join(
-        "."
-      )}}\t{dim.white ${tartufoSystemPath}}`
+      chalk`System\t{cyan Tartufo}\tVersion: {green ${
+        tartufoSystemVersion.join(
+          ".",
+        )
+      }}\t{dim.white ${tartufoSystemPath}}`,
     );
   }
 
   if (tartufoLocalPath) {
     const tartufoLocalVersion = await tartufoVersion(tartufoLocalPath);
     console.log(
-      chalk`Local\t{cyan Tartufo}\tVersion: {green ${tartufoLocalVersion.join(".")}}\t{dim.white ${tartufoLocalPath}}`
+      chalk`Local\t{cyan Tartufo}\tVersion: {green ${
+        tartufoLocalVersion.join(".")
+      }}\t{dim.white ${tartufoLocalPath}}`,
     );
   } else {
-    console.log(chalk`Local\t{cyan Tartufo}\t{yellow was not found.} (Expected if using system tartufo)`);
+    console.log(
+      chalk
+        `Local\t{cyan Tartufo}\t{yellow was not found.} (Expected if using system tartufo)`,
+    );
   }
 
   if (tartufoSystemPath && tartufoLocalPath) {
-    console.log("The global install of Tartufo is preferred, thus the local version will not be used.");
-    console.log(chalk`You can clean up your local install by running {cyan npx tartufo-helper reset}`);
-    console.log("Alternatively, you can uninstall your system copy of tartufo if it is not needed elsewhere.");
+    console.log(
+      "The global install of Tartufo is preferred, thus the local version will not be used.",
+    );
+    console.log(
+      chalk
+        `You can clean up your local install by running {cyan npx tartufo-helper reset}`,
+    );
+    console.log(
+      "Alternatively, you can uninstall your system copy of tartufo if it is not needed elsewhere.",
+    );
   }
 
   console.log("");
   console.log(
-    chalk`{green Your system is ready to use Tartufo!} You can try it out by running {cyan npx tartufo --version}`
+    chalk
+      `{green Your system is ready to use Tartufo!} You can try it out by running {cyan npx tartufo --version}`,
   );
-  console.log(chalk`You may also re-run this command with DEBUG=tartufo-node to see verbose logs`);
+  console.log(
+    chalk
+      `You may also re-run this command with DEBUG=tartufo-node to see verbose logs`,
+  );
 }
 
 async function commandReset() {
@@ -123,8 +178,12 @@ async function main() {
       console.error("tartufo-helper <command>");
       console.error("");
       console.error("Commands:");
-      console.error("  tartufo-helper doctor  Inspect and diagnose local setup issues");
-      console.error("  tartufo-helper reset   Resets tartufo, installing locally if necessary");
+      console.error(
+        "  tartufo-helper doctor  Inspect and diagnose local setup issues",
+      );
+      console.error(
+        "  tartufo-helper reset   Resets tartufo, installing locally if necessary",
+      );
       process.exit(1);
   }
 }

--- a/lib/git2-header.js
+++ b/lib/git2-header.js
@@ -1,0 +1,60 @@
+const { platform } = require("os");
+const { promisify } = require("util");
+const { access } = require("fs/promises");
+const { constants } = require("fs");
+const { join } = require("path");
+const exec = promisify(require("child_process").exec);
+
+const debug = require("debug")("tartufo-node");
+const { lookpath } = require("lookpath");
+
+const MAC_OS_PLATFORM = "darwin";
+const GIT_HEADER = "git2.h";
+const libPaths = ["/usr/include", "/usr/local/include"];
+
+/**
+ * Attempts to find the git2.h header file as it's a requirement to build libgit
+ * which is required to build pygit2 which is required by tartufo
+ *
+ * @returns {Promise<boolean>} is git2.h header present
+ */
+async function hasGit2Header() {
+  const paths = await getIncludePaths();
+  for (const path of paths) {
+    const fn = join(path, GIT_HEADER);
+    try {
+      await access(fn, constants.R_OK);
+      return true;
+      // eslint-disable-next-line no-empty
+    } catch (e) {}
+  }
+  return false;
+}
+
+/**
+ * Attempts to interrogate macOS for its SDK-specific header path, and returns
+ * an array of paths that could include system headers
+ *
+ * @returns {Promise<string[]>} file paths
+ */
+async function getIncludePaths() {
+  if (platform() === MAC_OS_PLATFORM) {
+    const xcrunPath = await lookpath("xcrun");
+    debug(`sh: ${xcrunPath} --show-sdk-path`);
+    const res = await exec(`${xcrunPath} --show-sdk-path`);
+    try {
+      res.stdout && debug(`sh: ${res.stdout.trimEnd()}`);
+      res.stderr && debug(`sh: ${res.stderr.trimEnd()}`);
+      return libPaths.concat(res.stdout.trim());
+    } catch (e) {
+      res.stdout && debug(`sh: ${res.stdout.trimEnd()}`);
+      res.stderr && debug(`sh: ${res.stderr.trimEnd()}`);
+      debug("Failed to run xcrun --show-sdk-path, will not check macOS specific paths");
+      return libPaths.concat([]);
+    }
+  } else {
+    return libPaths.concat([]);
+  }
+}
+
+module.exports = hasGit2Header;


### PR DESCRIPTION
Updates the doctor command to determine if libgit2 has been installed on the machine and its git2.h header (which is required for pygit2 which is required for tartufo) is present in a valid system include path.

Since this tool does not yet run on windows, that platform is ignored in this code.