### PR TITLE
Add support for configuring specific Tartufo version to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,22 @@ git add .husky/pre-commit
 
 Alternatively you could work with tartufo directly via npx, for example you could run `npx tartufo --help` in your project to see command line tools available to you.
 
+### Specifying a Tartufo version
+
+You may specify a Tartufo version using [Python version specifiers](https://peps.python.org/pep-0440/#version-specifiers). For example, if you want to install and use only Tartufo 3.x you can add the following to your `package.json`:
+
+```json
+{
+  "tartufo-node": {
+    "version": ">= 3.3.1, < 4.0.0"
+  }
+}
+```
+
+The `pip install` command will run _every_ postinstall cycle so you can rest assured that the local version will always remain up to date.
+
+Please note that the _global_ tartufo (the one available on your system) will always take precedence and the version config above will be ignored in those cases.
+
 ## Troubleshooting
 
 This package provides a `tartufo-helper` tool to help diagnose issues locally. To do so, run `npx tartufo-helper doctor` to see debugging output. If necessary, it may recommend you run `npx tartufo-helper reset` to reset your local installation.

--- a/lib/install-local.js
+++ b/lib/install-local.js
@@ -1,12 +1,17 @@
 /* eslint-disable no-console, max-statements */
 const chalk = require("chalk");
 const debug = require("debug")("tartufo-node");
-const systemPython = require("./python-system");
+const pythonSystem = require("./python-system");
+const pythonLocal = require("./python-local");
 const pythonVersion = require("./python-version");
 const pythonMeetsMinimum = require("./python-meets-minimum");
 const tartufoSystem = require("./tartufo-system");
 const streamSpawn = require("./stream-spawn");
 const { VENV_PATH, VENV_PYTHON_PATH } = require("./venv");
+const localConfig = require("./local-config");
+const { validate } = require("./python-version-specifier");
+const tartufoLocal = require("./tartufo-local");
+const tartufoVersion = require("./tartufo-version");
 
 /**
  * Sets up a local venv and uses the venv's pip to install Tartufo
@@ -21,6 +26,7 @@ async function installTartufoLocal() {
     return;
   }
 
+  const config = await localConfig();
   const tartufo = await tartufoSystem();
 
   if (tartufo) {
@@ -30,14 +36,14 @@ async function installTartufoLocal() {
 
   console.log("Tartufo is not globally installed, this package will now install a local copy...");
 
-  const python3 = await systemPython();
+  const pythonSystemPath = await pythonSystem();
 
-  if (!python3) {
+  if (!pythonSystemPath) {
     console.log(chalk.white.bgRed("Python 3 was not found on your system. Tartufo will not be installed."));
     console.log("Please run npx tartufo-helper doctor for more information on how to resolve");
     return;
   }
-  const version = await pythonVersion(python3);
+  const version = await pythonVersion(pythonSystemPath);
   if (!pythonMeetsMinimum(version)) {
     const localVersion = version.join(".");
     console.log(
@@ -49,18 +55,45 @@ async function installTartufoLocal() {
     return;
   }
 
-  debug("Settuping up venv...");
-  try {
-    await streamSpawn(debug, python3, ["-m", "venv", VENV_PATH]);
-  } catch (e) {
-    console.log(chalk.white.bgRed(`Tartufo failed to setup a local venv.`));
-    console.log(`Please run npx tartufo-helper doctor for more information on how to resolve`);
-    return;
+  const pythonLocalPath = await pythonLocal();
+  debug(pythonLocalPath);
+  if (!pythonLocalPath) {
+    debug("Settuping up venv...");
+    try {
+      await streamSpawn(debug, pythonSystemPath, ["-m", "venv", VENV_PATH]);
+    } catch (e) {
+      console.log(chalk.white.bgRed(`Tartufo failed to setup a local venv.`));
+      console.log(`Please run npx tartufo-helper doctor for more information on how to resolve`);
+      return;
+    }
+  } else {
+    debug("Found existing venv...");
   }
 
   debug("Installing tartufo...");
   try {
-    await streamSpawn(debug, VENV_PYTHON_PATH, ["-m", "pip", "install", "tartufo"]);
+    if (config?.version) {
+      if (!validate(config.version)) {
+        console.log(chalk.white.bgRed(`Invalid Tartufo version provided.`));
+        console.log(`Value of ${config.version} is not a valid Python PEP 440 version specifier`);
+        console.log(`Installation will NOT continue, please see https://peps.python.org/pep-0440/#version-specifiers`);
+        return;
+      }
+
+      await streamSpawn(debug, VENV_PYTHON_PATH, ["-m", "pip", "install", `"tartufo${config.version}"`]);
+    } else {
+      await streamSpawn(debug, VENV_PYTHON_PATH, ["-m", "pip", "install", "tartufo"]);
+    }
+  } catch (e) {
+    console.log(chalk.white.bgRed(`Tartufo failed to install.`));
+    console.log(`Please run npx tartufo-helper doctor for more information on how to resolve`);
+    return;
+  }
+
+  try {
+    const localTartufo = await tartufoLocal();
+    const localVersion = await tartufoVersion(localTartufo);
+    console.log(chalk.green(`Tartufo v${localVersion.join(".")} successfully installed!`));
   } catch (e) {
     console.log(chalk.white.bgRed(`Tartufo failed to install.`));
     console.log(`Please run npx tartufo-helper doctor for more information on how to resolve`);

--- a/lib/local-config.js
+++ b/lib/local-config.js
@@ -1,0 +1,15 @@
+const { lilconfig } = require("lilconfig");
+
+// No options to override for now!
+const OPTIONS = {};
+let _cache;
+
+async function localConfig() {
+  if (!_cache) {
+    const { config } = await lilconfig("tartufo-node", OPTIONS).search();
+    _cache = config;
+  }
+  return _cache;
+}
+
+module.exports = localConfig;

--- a/lib/python-version-specifier.js
+++ b/lib/python-version-specifier.js
@@ -1,0 +1,18 @@
+const SPECIFIER_REGEX = /^(~=|===?|!=|<=?|>=?)\s*([0-9]+(\.([0-9a-zA-Z]+|\*))*)$/;
+
+/**
+ * Validates a Python version specifier as per PEP 440
+ *
+ * @see https://peps.python.org/pep-0440/#version-specifiers
+ * @param {string} specifier A potential Python version specifier
+ * @returns {boolean} Whether or not it meets PEP 440 spec
+ */
+function validate(specifier) {
+  // Specifiers can be separated and combined via commas, so lets split the string and test every specifier
+  const allSpecifiers = specifier.split(",").map(segment => segment.trim());
+  return Boolean(allSpecifiers.every(spec => spec.match(SPECIFIER_REGEX)));
+}
+
+module.exports = {
+  validate,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "debug": "^4.3.4",
         "global-dirs": "^3.0.1",
         "is-installed-globally": "^0.4.0",
+        "lilconfig": "^2.1.0",
         "lookpath": "^1.2.2"
       },
       "bin": {
@@ -3721,10 +3722,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
-      "dev": true,
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
       "engines": {
         "node": ">=10"
       }
@@ -3816,6 +3816,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lint-staged/node_modules/lilconfig": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/lint-staged/node_modules/mimic-fn": {
@@ -8291,10 +8300,9 @@
       }
     },
     "lilconfig": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
-      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
-      "dev": true
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
+      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ=="
     },
     "lines-and-columns": {
       "version": "1.2.4",
@@ -8356,6 +8364,12 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
           "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+          "dev": true
+        },
+        "lilconfig": {
+          "version": "2.0.6",
+          "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+          "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
           "dev": true
         },
         "mimic-fn": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "npm run test:unit",
-    "test:unit": "exit 0",
+    "test:unit": "jest ./tests/unit",
     "test:integration": "jest ./tests/integration",
     "lint": "eslint .",
     "clean": "node ./lib/clean-local.js",
@@ -41,6 +41,7 @@
     "debug": "^4.3.4",
     "global-dirs": "^3.0.1",
     "is-installed-globally": "^0.4.0",
+    "lilconfig": "^2.1.0",
     "lookpath": "^1.2.2"
   },
   "devDependencies": {
@@ -57,5 +58,8 @@
   "lint-staged": {
     "*.{js,css,md}": "prettier --write",
     "*.js": "eslint --fix"
+  },
+  "tartufo-node": {
+    "version": ">= 3.3.1, < 4.0.0"
   }
 }

--- a/tests/unit/python-version-specifier.test.js
+++ b/tests/unit/python-version-specifier.test.js
@@ -1,0 +1,81 @@
+const { validate } = require("../../lib/python-version-specifier");
+
+describe("python-version-specifier", () => {
+  test("Validates Compatible Release clause (~=)", async () => {
+    expect(validate("~=0.9")).toStrictEqual(true);
+    expect(validate("~=2014.3")).toStrictEqual(true);
+    expect(validate("~=1.2.3beta1")).toStrictEqual(true);
+    expect(validate("~=1.2.pre3.test4")).toStrictEqual(true);
+  });
+  test("Validates Version Matching clause (==)", async () => {
+    expect(validate("==1.2.3")).toStrictEqual(true);
+    expect(validate("==2012.4")).toStrictEqual(true);
+    expect(validate("==1.2.3alpha1")).toStrictEqual(true);
+    expect(validate("==1.2.pre3.dev4")).toStrictEqual(true);
+  });
+  test("Validates Version Exclusion clause (!=)", async () => {
+    expect(validate("!=1.2.3")).toStrictEqual(true);
+    expect(validate("!=2012.4")).toStrictEqual(true);
+    expect(validate("!=1.2.3alpha1")).toStrictEqual(true);
+    expect(validate("!=1.2.post3.dev4")).toStrictEqual(true);
+  });
+  test("Validates Inclusive Ordered Comparison clause (>=, <=)", async () => {
+    expect(validate(">=1.2.3")).toStrictEqual(true);
+    expect(validate(">=2012.4")).toStrictEqual(true);
+    expect(validate(">=1.2.3alpha1")).toStrictEqual(true);
+    expect(validate(">=1.2.post3.dev4")).toStrictEqual(true);
+    expect(validate("<=1.2.3")).toStrictEqual(true);
+    expect(validate("<=2012.4")).toStrictEqual(true);
+    expect(validate("<=1.2.3alpha1")).toStrictEqual(true);
+    expect(validate("<=1.2.post3.dev4")).toStrictEqual(true);
+  });
+  test("Validates Exclusive Ordered Comparison clause", async () => {
+    expect(validate(">1.2.3")).toStrictEqual(true);
+    expect(validate(">2012.4")).toStrictEqual(true);
+    expect(validate(">1.2.3alpha1")).toStrictEqual(true);
+    expect(validate(">1.2.post3.dev4")).toStrictEqual(true);
+  });
+  test("Validates Arbitrary Equality clause", async () => {
+    expect(validate("===1.2.3")).toStrictEqual(true);
+    expect(validate("===2012.4")).toStrictEqual(true);
+    expect(validate("===1.2.3alpha1")).toStrictEqual(true);
+    expect(validate("===1.2.post3.dev4")).toStrictEqual(true);
+  });
+  test("Validates compound specifiers", async () => {
+    expect(validate("===1.2.3, >1.2.3, <=1.2.3, !=1.2.3alpha1, ==1.2.pre3.dev4, ~=1.2.pre3.test4")).toStrictEqual(true);
+  });
+  test("Rejects specifier without a clause", async () => {
+    expect(validate("0.9")).toStrictEqual(false);
+    expect(validate("2014.3")).toStrictEqual(false);
+    expect(validate("1.2.3beta1")).toStrictEqual(false);
+    expect(validate("1.2.pre3.test4")).toStrictEqual(false);
+  });
+  test("Rejects invalid specifier with a valid clause", async () => {
+    expect(validate("~=.9")).toStrictEqual(false);
+    expect(validate("==.2.3")).toStrictEqual(false);
+    expect(validate("!=.2.3")).toStrictEqual(false);
+    expect(validate(">.2.3")).toStrictEqual(false);
+    expect(validate("===.2.3")).toStrictEqual(false);
+  });
+  test("Rejects compound specifiers with trailing commas", async () => {
+    expect(validate("===1.2.3, >1.2.3, <=1.2.3,")).toStrictEqual(false);
+  });
+  test("Rejects compound specifiers with leading commas", async () => {
+    expect(validate(",===1.2.3, >1.2.3, <=1.2.3")).toStrictEqual(false);
+  });
+  test("Rejects compound specifiers with missing commas", async () => {
+    expect(validate("===1.2.3 >1.2.3, <=1.2.3")).toStrictEqual(false);
+  });
+  test("Rejects equality clause with too many = signs", async () => {
+    expect(validate("====1.2.3")).toStrictEqual(false);
+    expect(validate("====2012.4")).toStrictEqual(false);
+    expect(validate("====1.2.3alpha1")).toStrictEqual(false);
+    expect(validate("====1.2.post3.dev4")).toStrictEqual(false);
+  });
+  test("Rejects equality clause with too few = signs", async () => {
+    expect(validate("=1.2.3")).toStrictEqual(false);
+    expect(validate("=2012.4")).toStrictEqual(false);
+    expect(validate("=1.2.3alpha1")).toStrictEqual(false);
+    expect(validate("=1.2.post3.dev4")).toStrictEqual(false);
+  });
+});


### PR DESCRIPTION
Allows downstream users to add a `tartufo-node` stanza to their package.json files to specify a version of Tartufo to ensure is installed locally, e.g.:

```json
{
  "tartufo-node": {
    "version": ">= 3.3.1, < 4.0.0"
  }
}
```

The version specification follows PEP 440 given that it is passed _directly_ `pip install ...`

This currently only works when the system revers to _local_ python mode. Future improvements could be made to _force_ local install via the configuration pathway as well as automatically check the system version for compatibility.

Closes #17